### PR TITLE
Noetic nodelet fixes

### DIFF
--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -33,6 +33,7 @@ find_package(catkin REQUIRED COMPONENTS
   vision_msgs
   depthai_bridge
   message_filters
+  nodelet
 )
 
 set(_opencv_version 4)

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -101,6 +101,14 @@ target_link_libraries(nodelet_stereo
   opencv_highgui
 )
 
+target_link_options(nodelet_stereo PRIVATE
+  -Wl,--no-undefined
+)
+
+target_link_options(${PROJECT_NAME} PRIVATE
+  -Wl,--no-undefined
+)
+
 
 # hunter_private_data(
 #     URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/mobilenet-ssd_openvino_2021.2_6shave.blob"

--- a/depthai_examples/launch/stereo_nodelet.launch
+++ b/depthai_examples/launch/stereo_nodelet.launch
@@ -34,22 +34,15 @@
         <arg name="cam_yaw"         value="$(arg  cam_yaw)"     />
     </include>
 
-
-    <node name="stereo_publisher" pkg="depthai_examples" type="stereo_node" output="screen" required="true">
-        <param name="camera_name" value="$(arg camera_name)"/>
-        <param name="camera_param_uri" value="$(arg camera_param_uri)"/>
-    </node>            
-
-
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~  depth_image_proc nodelet below ~~~~~~~~~~~~~~~~~~~ -->
 
     <node pkg="nodelet" type="nodelet" name="nodelet_manager"  args="manager" output="screen"/>
-    
-    <!-- <node pkg="nodelet" type="nodelet" name="nodelet_manager"  args="manager" output="screen">
+
+    <node name="stereo_publisher" pkg="nodelet" type="nodelet" output="screen" required="true"
+        args="load depthai_examples/StereoNodelet nodelet_manager">
         <param name="camera_name" value="$(arg camera_name)"/>
         <param name="camera_param_uri" value="$(arg camera_param_uri)"/>
-    </node> -->
-
+    </node>
 
     <node pkg="nodelet" type="nodelet" name="depth_image_convertion_nodelet"
         args="load depth_image_proc/convert_metric nodelet_manager">

--- a/depthai_examples/src/stereo_nodelet.cpp
+++ b/depthai_examples/src/stereo_nodelet.cpp
@@ -19,10 +19,16 @@ namespace depthai_examples{
 
  class StereoNodelet : public nodelet::Nodelet
 {
-    public:
-        virtual void onInit(){
 
-            ros::NodeHandle pnh("~");
+    std::unique_ptr<StereoExampe> stereo_pipeline;
+    std::vector<std::shared_ptr<dai::DataOutputQueue>> imageDataQueues;
+    std::unique_ptr<dai::rosBridge::BridgePublisher<sensor_msgs::Image, dai::ImgFrame>> leftPublish, rightPublish, depthPublish;
+    std::unique_ptr<dai::rosBridge::ImageConverter> leftConverter, rightConverter;
+
+    public:
+        virtual void onInit() override {
+
+            auto& pnh = getPrivateNodeHandle();
             
             std::string deviceName;
             std::string camera_param_uri;
@@ -36,80 +42,77 @@ namespace depthai_examples{
                 throw std::runtime_error("Couldn't find one of the parameters");
             }
 
-            StereoExampe stero_pipeline;
-            stero_pipeline.initDepthaiDev();
-            std::vector<std::shared_ptr<dai::DataOutputQueue>> imageDataQueues = stero_pipeline.getExposedImageStreams();
+            stereo_pipeline = std::make_unique<StereoExampe>();
+            stereo_pipeline->initDepthaiDev();
+            imageDataQueues = stereo_pipeline->getExposedImageStreams();
             
             std::vector<ros::Publisher> imgPubList;
             std::vector<std::string> frameNames;
             
             // this part would be removed once we have calibration-api
             std::string left_uri = camera_param_uri +"/" + "left.yaml";
-        
-            std::string right_uri = camera_param_uri + "/" + "right.yaml";
-            
-            std::string stereo_uri = camera_param_uri + "/" + "right.yaml";
-            
 
-        
-            dai::rosBridge::ImageConverter converter(deviceName + "_left_camera_optical_frame", true);
-            dai::rosBridge::BridgePublisher<sensor_msgs::Image, dai::ImgFrame> leftPublish(imageDataQueues[0],
-                                                                                            pnh, 
-                                                                                            std::string("left/image"),
-                                                                                            std::bind(&dai::rosBridge::ImageConverter::toRosMsg, 
-                                                                                            &converter, 
-                                                                                            std::placeholders::_1, 
-                                                                                            std::placeholders::_2) , 
-                                                                                            30,
-                                                                                            left_uri,
-                                                                                            "left");
+            std::string right_uri = camera_param_uri + "/" + "right.yaml";
+
+            std::string stereo_uri = camera_param_uri + "/" + "right.yaml";
+
+            leftConverter = std::make_unique<dai::rosBridge::ImageConverter>(deviceName + "_left_camera_optical_frame", true);
+            leftPublish  = std::make_unique<dai::rosBridge::BridgePublisher<sensor_msgs::Image, dai::ImgFrame>>
+                (imageDataQueues[0],
+                pnh, 
+                std::string("left/image"),
+                std::bind(&dai::rosBridge::ImageConverter::toRosMsg, 
+                leftConverter.get(),
+                std::placeholders::_1, 
+                std::placeholders::_2) , 
+                1,
+                left_uri,
+                "left");
 
             // bridgePublish.startPublisherThread();
-            leftPublish.addPubisherCallback();
+            leftPublish->addPubisherCallback();
 
-            dai::rosBridge::ImageConverter rightconverter(deviceName + "_right_camera_optical_frame", true);
-            dai::rosBridge::BridgePublisher<sensor_msgs::Image, dai::ImgFrame> rightPublish(imageDataQueues[1],
-                                                                                            pnh, 
-                                                                                            std::string("right/image"),
-                                                                                            std::bind(&dai::rosBridge::ImageConverter::toRosMsg, 
-                                                                                            &rightconverter, 
-                                                                                            std::placeholders::_1, 
-                                                                                            std::placeholders::_2) , 
-                                                                                            30,
-                                                                                            right_uri,
-                                                                                            "right");
+            rightConverter = std::make_unique<dai::rosBridge::ImageConverter >(deviceName + "_right_camera_optical_frame", true);
+            rightPublish = std::make_unique<dai::rosBridge::BridgePublisher<sensor_msgs::Image, dai::ImgFrame>>
+                (imageDataQueues[1],
+                pnh, 
+                std::string("right/image"),
+                std::bind(&dai::rosBridge::ImageConverter::toRosMsg, 
+                rightConverter.get(), 
+                std::placeholders::_1, 
+                std::placeholders::_2) , 
+                1,
+                right_uri,
+                "right");
 
-            rightPublish.addPubisherCallback();
+            rightPublish->addPubisherCallback();
 
             // dai::rosBridge::ImageConverter depthConverter(deviceName + "_right_camera_optical_frame");
-            dai::rosBridge::BridgePublisher<sensor_msgs::Image, dai::ImgFrame> depthPublish(imageDataQueues[2],
-                                                                                            pnh, 
-                                                                                            std::string("stereo/depth"),
-                                                                                            std::bind(&dai::rosBridge::ImageConverter::toRosMsg, 
-                                                                                            &rightconverter, // since the converter has the same frame name
-                                                                                                            // and image type is also same we can reuse it
-                                                                                            std::placeholders::_1, 
-                                                                                            std::placeholders::_2) , 
-                                                                                            30,
-                                                                                            stereo_uri,
-                                                                                            "stereo");
+            depthPublish = std::make_unique<dai::rosBridge::BridgePublisher<sensor_msgs::Image, dai::ImgFrame>>
+                (imageDataQueues[2],
+                pnh, 
+                std::string("stereo/depth"),
+                std::bind(&dai::rosBridge::ImageConverter::toRosMsg, 
+                rightConverter.get(), // since the converter has the same frame name
+                                // and image type is also same we can reuse it
+                std::placeholders::_1, 
+                std::placeholders::_2) , 
+                1,
+                stereo_uri,
+                "stereo");
 
-            depthPublish.addPubisherCallback();
+            depthPublish->addPubisherCallback();
 
             // We can add the rectified frames also similar to these publishers. 
             // Left them out so that users can play with it by adding and removing
-
-            ros::spin();
-
-            return ;
         }
 };
 
-PLUGINLIB_EXPORT_CLASS(depthai_examples::StereoNodelet, nodelet::Nodelet)
+//PLUGINLIB_EXPORT_CLASS(depthai_examples::StereoNodelet, nodelet::Nodelet)
 
 
 }   // namespace depthai_examples
-// PLUGINLIB_EXPORT_CLASS(depthai_examples::StereoNodelet, nodelet::Nodelet)
+PLUGINLIB_EXPORT_CLASS(depthai_examples::StereoNodelet, nodelet::Nodelet)
 
 
 


### PR DESCRIPTION
Currently, [`stereo_nodelet.cpp`](https://github.com/luxonis/depthai-ros-examples/blob/73f7d3e9a12c94a2ef313d1b721fe840a76ac136/depthai_examples/src/stereo_nodelet.cpp) uses a blocking `onInit()` method. This is not how ROS expects onInit to work: [the wiki says this method should not block or do significat work](http://wiki.ros.org/nodelet#onInit).

This pull request attempts to rectify that. It also changes the `stereo_nodelet.launch` file to actually launch the nodelet.