### PR TITLE
add required param otherwise nodelet wont load

### DIFF
--- a/depthai_examples/launch/stereo_nodelet.launch
+++ b/depthai_examples/launch/stereo_nodelet.launch
@@ -42,6 +42,7 @@
         args="load depthai_examples/StereoNodelet nodelet_manager">
         <param name="camera_name" value="$(arg camera_name)"/>
         <param name="camera_param_uri" value="$(arg camera_param_uri)"/>
+        <param name="mode" value="depth"/>
     </node>
 
     <node pkg="nodelet" type="nodelet" name="depth_image_convertion_nodelet"


### PR DESCRIPTION
Without this param, the nodelet fails to load with a very undescriptive error message:
```
(/depthai_examples_StereoNodelet) [ INFO] [2021-08-10 08:05:19]: Loading nodelet /depthai_examples_StereoNodelet of type depthai_examples/StereoNodelet to manager /nodelet_manager with the following remappings:
(/depthai_examples_StereoNodelet) [FATAL] [2021-08-10 08:05:19]: Failed to load nodelet '/depthai_examples_StereoNodelet` of type `depthai_examples/StereoNodelet` to manager `/nodelet_manager'
```