### PR TITLE
Pr publish imu transform

### DIFF
--- a/depthai_examples/launch/stereo_inertial_node.launch
+++ b/depthai_examples/launch/stereo_inertial_node.launch
@@ -4,8 +4,10 @@
     <arg name="camera_model"         default="OAK-D"       /> <!-- 'zed' or 'zedm' -->
     <arg name="tf_prefix"            default="oak"         />
     <arg name="mode"                 default="depth"       />
+    <arg name="world_frame"           default="map" />
     <arg name="base_frame"           default="oak-d_frame" />
     <arg name="parent_frame"         default="oak-d-base-frame" />
+    <arg name="publish_imu_transform"   default="false" />
 
     <arg name="cam_pos_x"             default="0.0"        /> <!-- Position respect to base frame (i.e. "base_link) -->
     <arg name="cam_pos_y"             default="0.0"        /> <!-- Position respect to base frame (i.e. "base_link) -->
@@ -51,6 +53,9 @@
         <param name="confidence"     value="$(arg confidence)" />
         <param name="LRchecktresh"   value="$(arg LRchecktresh)" />
         <param name="monoResolution" value="$(arg monoResolution)" />
+        <param name="base_frame"            value="$(arg base_frame)" />
+        <param name="world_frame"            value="$(arg world_frame)" />
+        <param name="publish_imu_transform" value="$(arg publish_imu_transform)" />
     </node>            
 
     <node pkg="nodelet" type="nodelet" name="nodelet_manager"  args="manager" output="screen"/>

--- a/depthai_examples/launch/stereo_inertial_node.launch.py
+++ b/depthai_examples/launch/stereo_inertial_node.launch.py
@@ -19,6 +19,8 @@ def generate_launch_description():
     tf_prefix    = LaunchConfiguration('tf_prefix',   default = 'oak')
     base_frame   = LaunchConfiguration('base_frame',    default = 'oak-d_frame')
     parent_frame = LaunchConfiguration('parent_frame',  default = 'oak-d-base-frame')
+    world_frame = LaunchConfiguration('world_frame',  default = 'map')
+    publish_imu_transform = LaunchConfiguration('publish_imu_transform',  default = False)
     
     cam_pos_x    = LaunchConfiguration('cam_pos_x',     default = '0.0')
     cam_pos_y    = LaunchConfiguration('cam_pos_y',     default = '0.0')
@@ -132,6 +134,16 @@ def generate_launch_description():
         'confidence',
         default_value=confidence,
         description='The name of the camera. It can be different from the camera model and it will be used as node `namespace`.')
+
+    declare_publish_imu_transform_cmd = DeclareLaunchArgument(
+        'publish_imu_transform',
+        default_value=publish_imu_transform,
+        description='set whether to publish IMU orientaion as a transform in the parent frame')
+
+    declare_world_frame_cmd = DeclareLaunchArgument(
+        'world_frame',
+        default_value=world_frame,
+        description='set world frame for transforms')
     
     
     urdf_launch = IncludeLaunchDescription(
@@ -161,7 +173,10 @@ def generate_launch_description():
                         {'depth_aligned': depth_aligned},
                         {'stereo_fps':    stereo_fps},
                         {'confidence':    confidence},
-                        {'LRchecktresh':  LRchecktresh}])
+                        {'LRchecktresh':  LRchecktresh},
+                        {'world_frame':  world_frame},
+                        {'parent_frame':  base_frame},
+                        {'publish_imu_transform': publish_imu_transform}])
 
     metric_converter_node = launch_ros.actions.ComposableNodeContainer(
             name='container',
@@ -229,6 +244,8 @@ def generate_launch_description():
     ld.add_action(declare_stereo_fps_cmd)
     ld.add_action(declare_LRchecktresh_cmd)
     ld.add_action(declare_confidence_cmd)
+    ld.add_action(declare_world_frame_cmd)
+    ld.add_action(declare_publish_imu_transform_cmd)
 
     ld.add_action(streo_node)
     ld.add_action(urdf_launch)

--- a/depthai_examples/ros1_src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/ros1_src/stereo_inertial_publisher.cpp
@@ -138,10 +138,10 @@ int main(int argc, char** argv){
     ros::init(argc, argv, "stereo_inertial_node");
     ros::NodeHandle pnh("~");
 
-    std::string tfPrefix, mode;
+    std::string tfPrefix, mode, base_frame, world_frame;
     std::string monoResolution = "720p";
     int badParams = 0, stereo_fps, confidence, LRchecktresh;
-    bool lrcheck, extended, subpixel, enableDepth, rectify, depth_aligned;
+    bool lrcheck, extended, subpixel, enableDepth, rectify, depth_aligned, publish_imu_transform;
 
     badParams += !pnh.getParam("tf_prefix", tfPrefix);
     badParams += !pnh.getParam("mode", mode);
@@ -154,6 +154,9 @@ int main(int argc, char** argv){
     badParams += !pnh.getParam("confidence",  confidence);
     badParams += !pnh.getParam("LRchecktresh",  LRchecktresh);
     badParams += !pnh.getParam("monoResolution",   monoResolution);
+    badParams += !pnh.getParam("base_frame",  base_frame);
+    badParams += !pnh.getParam("world_frame",  world_frame);
+    badParams += !pnh.getParam("publish_imu_transform",  publish_imu_transform);
 
     if (badParams > 0)
     {   
@@ -197,7 +200,7 @@ int main(int argc, char** argv){
     const std::string leftPubName = rectify?std::string("left/image_rect"):std::string("left/image_raw");
     const std::string rightPubName = rectify?std::string("right/image_rect"):std::string("right/image_raw");
 
-    dai::rosBridge::ImuConverter imuConverter(tfPrefix + "_imu_frame");
+    dai::rosBridge::ImuConverter imuConverter(tfPrefix + "_imu_frame", publish_imu_transform, base_frame, world_frame);
 
     dai::rosBridge::BridgePublisher<sensor_msgs::Imu, dai::IMUData> ImuPublish(imuQueue,
                                                                                      pnh, 
@@ -208,7 +211,8 @@ int main(int argc, char** argv){
                                                                                      std::placeholders::_2) , 
                                                                                      30,
                                                                                      "",
-                                                                                     "imu");
+                                                                                     "imu",
+                                                                                     publish_imu_transform);
 
     ImuPublish.addPublisherCallback();
     int colorWidth = 1280, colorHeight = 720;


### PR DESCRIPTION
Added feature to publish the IMU transform to a passed world frame. Both world frame and boolean "publish_imu_transform" added to ros and ros2 launch files for the inertial_stereo_node. Parameters are added to IMU and BridgePublisher constructors so recommend PR for dephai-ros first.