### PR TITLE
IR Support for rgb_stereo_node

### DIFF
--- a/depthai_examples/launch/rgb_stereo_node.launch.py
+++ b/depthai_examples/launch/rgb_stereo_node.launch.py
@@ -42,8 +42,8 @@ def generate_launch_description():
     previewHeight   = LaunchConfiguration('previewHeight',   default = 300)
 
     # IR Brightness. OAK-D-Pro only.
-    irDotBrightness   = LaunchConfiguration('irDotBrightness',     default = 0.0)
-    irFloodBrightness = LaunchConfiguration('irFloodBrightness',   default = 0.0)
+    dotProjectormA   = LaunchConfiguration('dotProjectormA',     default = 0.0)
+    floodLightmA     = LaunchConfiguration('floodLightmA',       default = 0.0)
 
     declare_camera_model_cmd = DeclareLaunchArgument(
         'camera_model',
@@ -156,14 +156,14 @@ def generate_launch_description():
         default_value=previewHeight,
         description='Height of preview image')
 
-    declare_irDotBrightness_cmd = DeclareLaunchArgument(
-        'irDotBrightness',
-        default_value=irDotBrightness,
+    declare_dotProjectormA_cmd = DeclareLaunchArgument(
+        'dotProjectormA',
+        default_value=dotProjectormA,
         description='Brightness of IR Dot projector on OAK-D-Pro in mA.')
 
-    declare_irFloodBrightness_cmd = DeclareLaunchArgument(
-        'irFloodBrightness',
-        default_value=irFloodBrightness,
+    declare_floodLightmA_cmd = DeclareLaunchArgument(
+        'floodLightmA',
+        default_value=floodLightmA,
         description='Brightness of IR Flood LED on OAK-D-Pro in mA.')
 
     urdf_launch = IncludeLaunchDescription(
@@ -196,8 +196,8 @@ def generate_launch_description():
                         {'useDepth': useDepth},
                         {'previewWidth': previewWidth},
                         {'previewHeight': previewHeight},
-                        {'irDotBrightness': irDotBrightness},
-                        {'irFloodBrightness': irFloodBrightness}])
+                        {'dotProjectormA': dotProjectormA},
+                        {'floodLightmA': floodLightmA}])
 
     metric_converter_node = launch_ros.actions.ComposableNodeContainer(
             name='container',
@@ -270,8 +270,8 @@ def generate_launch_description():
     ld.add_action(declare_previewWidth_cmd)
     ld.add_action(declare_previewHeight_cmd)
 
-    ld.add_action(declare_irDotBrightness_cmd)
-    ld.add_action(declare_irFloodBrightness_cmd)
+    ld.add_action(declare_dotProjectormA_cmd)
+    ld.add_action(declare_floodLightmA_cmd)
 
     ld.add_action(rgb_stereo_node)
     ld.add_action(urdf_launch)

--- a/depthai_examples/launch/rgb_stereo_node.launch.py
+++ b/depthai_examples/launch/rgb_stereo_node.launch.py
@@ -41,6 +41,10 @@ def generate_launch_description():
     previewWidth    = LaunchConfiguration('previewWidth',    default = 300)
     previewHeight   = LaunchConfiguration('previewHeight',   default = 300)
 
+    # IR Brightness. OAK-D-Pro only.
+    irDotBrightness   = LaunchConfiguration('irDotBrightness',     default = 0.0)
+    irFloodBrightness = LaunchConfiguration('irFloodBrightness',   default = 0.0)
+
     declare_camera_model_cmd = DeclareLaunchArgument(
         'camera_model',
         default_value=camera_model,
@@ -152,6 +156,16 @@ def generate_launch_description():
         default_value=previewHeight,
         description='Height of preview image')
 
+    declare_irDotBrightness_cmd = DeclareLaunchArgument(
+        'irDotBrightness',
+        default_value=irDotBrightness,
+        description='Brightness of IR Dot projector on OAK-D-Pro in mA.')
+
+    declare_irFloodBrightness_cmd = DeclareLaunchArgument(
+        'irFloodBrightness',
+        default_value=irFloodBrightness,
+        description='Brightness of IR Flood LED on OAK-D-Pro in mA.')
+
     urdf_launch = IncludeLaunchDescription(
                             launch_description_sources.PythonLaunchDescriptionSource(
                                     os.path.join(urdf_launch_dir, 'urdf_launch.py')),
@@ -181,7 +195,9 @@ def generate_launch_description():
                         {'usePreview': usePreview},
                         {'useDepth': useDepth},
                         {'previewWidth': previewWidth},
-                        {'previewHeight': previewHeight}])
+                        {'previewHeight': previewHeight},
+                        {'irDotBrightness': irDotBrightness},
+                        {'irFloodBrightness': irFloodBrightness}])
 
     metric_converter_node = launch_ros.actions.ComposableNodeContainer(
             name='container',
@@ -253,6 +269,9 @@ def generate_launch_description():
     ld.add_action(declare_useDepth_cmd)
     ld.add_action(declare_previewWidth_cmd)
     ld.add_action(declare_previewHeight_cmd)
+
+    ld.add_action(declare_irDotBrightness_cmd)
+    ld.add_action(declare_irFloodBrightness_cmd)
 
     ld.add_action(rgb_stereo_node)
     ld.add_action(urdf_launch)

--- a/depthai_examples/ros2_src/rgb_stereo_node.cpp
+++ b/depthai_examples/ros2_src/rgb_stereo_node.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv){
     bool lrcheck, extended, subpixel;
     bool useVideo, usePreview, useDepth;
     int confidence, LRchecktresh, previewWidth, previewHeight;
-    float irDotBrightness, irFloodBrightness;
+    float dotProjectormA, floodLightmA;
 
     node->declare_parameter("tf_prefix", "oak");
     node->declare_parameter("lrcheck", true);
@@ -136,8 +136,8 @@ int main(int argc, char** argv){
     node->declare_parameter("useDepth", true);
     node->declare_parameter("previewWidth", 300);
     node->declare_parameter("previewHeight", 300);
-    node->declare_parameter("irDotBrightness", 0.0f);
-    node->declare_parameter("irFloodBrightness", 0.0f);
+    node->declare_parameter("dotProjectormA", 0.0f);
+    node->declare_parameter("floodLightmA", 0.0f);
 
     node->get_parameter("tf_prefix", tfPrefix);
     node->get_parameter("lrcheck",  lrcheck);
@@ -152,8 +152,8 @@ int main(int argc, char** argv){
     node->get_parameter("useDepth", useDepth);
     node->get_parameter("previewWidth", previewWidth);
     node->get_parameter("previewHeight", previewHeight);
-    node->get_parameter("irDotBrightness", irDotBrightness);
-    node->get_parameter("irFloodBrightness", irFloodBrightness);
+    node->get_parameter("dotProjectormA", dotProjectormA);
+    node->get_parameter("floodLightmA", floodLightmA);
 
     int colorWidth, colorHeight;
     if(colorResolution == "1080p"){
@@ -259,8 +259,9 @@ int main(int argc, char** argv){
     // We can add the rectified frames also similar to these publishers. 
     // Left them out so that users can play with it by adding and removing
 
-    float currentDotBrightness = 0.0f;
-    float currentFloodBrightness = 0.0f;
+    // IR currents
+    float currentDotmA = 0.0f;
+    float currentFloodmA = 0.0f;
 
     while (rclcpp::ok()){
         // Spin some to allow parameters to be changed
@@ -269,23 +270,22 @@ int main(int argc, char** argv){
         // Allow IR usage on OAK-D-Pro's
         if(boardName == "OAK-D-PRO")
         {
-            node->get_parameter("irDotBrightness", irDotBrightness);
+            node->get_parameter("dotProjectormA", dotProjectormA);
 
-            if (currentDotBrightness != irDotBrightness){
-                currentDotBrightness = irDotBrightness;
-                device.setIrLaserDotProjectorBrightness(currentDotBrightness);
-                std::cout << "Updated IR Dot Projector Brightness " << currentDotBrightness << std::endl;
+            if (currentDotmA != dotProjectormA){
+                currentDotmA = dotProjectormA;
+                device.setIrLaserDotProjectorBrightness(currentDotmA);
+                std::cout << "Updated IR Dot Projector Brightness " << currentDotmA << std::endl;
             }
 
-            node->get_parameter("irFloodBrightness", irFloodBrightness);
+            node->get_parameter("floodLightmA", floodLightmA);
 
-            if (currentFloodBrightness != irFloodBrightness){
-                currentFloodBrightness = irFloodBrightness;
-                device.setIrLaserDotProjectorBrightness(currentFloodBrightness);
-                std::cout << "Updated IR Flood Light Brightness " << currentFloodBrightness << std::endl;
+            if (currentFloodmA != floodLightmA){
+                currentFloodmA = floodLightmA;
+                device.setIrLaserDotProjectorBrightness(currentFloodmA);
+                std::cout << "Updated IR Flood Light Brightness " << currentFloodmA << std::endl;
             }
         }
-        
     }
 
     return 0;


### PR DESCRIPTION
- Added parameters for setting the brightness of the IR dot projector and flood light on the OAK-D-Pro.
- Parameters can be set at launch and updated during runtime.

Example usage:
`ros2 launch depthai_examples rgb_stereo_node.launch.py dotProjectormA:=200.0 floodLightmA:=200.0`

Changing brightness during runtime:
`ros2 param set /rgb_stereo_node dotProjectormA 250.0`